### PR TITLE
Added default listening address "127.0.0.1:8080"

### DIFF
--- a/crema.go
+++ b/crema.go
@@ -173,7 +173,16 @@ func main() {
 			}
 		}
 	})
-	r.Run(os.Getenv("PORT"))
+
+	// Initialize variable with default value
+	var listenAddress string
+	if os.Getenv("ADDRESS") != "" {
+		listenAddress = os.Getenv("ADDRESS")
+	} else {
+		listenAddress = "127.0.0.1:8080"
+		log.Warn("Environment variable \"ADDRESS\" not set. Using default address 127.0.0.1:8080")
+	}
+	r.Run(listenAddress)
 }
 
 func monitorGames(c *Cache) {


### PR DESCRIPTION
- Renamed env "PORT" to "ADDRESS"
- Added default listening address "127.0.0.1:8080"
- Warning displayed when ADDRESS is not set. I am also fine with Info but a little yellow in the console may safe some time when setup CREMA by getting attention on this environment variable.